### PR TITLE
Add specificity + links to Sublime pkg suggestions

### DIFF
--- a/pages/start.html
+++ b/pages/start.html
@@ -101,9 +101,11 @@ library that can be composed well with reapp</li>
 <h3 id="development-environment">Development Environment</h3>
 <p>Sublime users, some helpful plugins for you to install:</p>
 <ul>
-<li>SublimeLinter</li>
-<li>eshint</li>
-<li>JavaScript Next - ES6 Syntax</li>
+  <li>
+    <a href="http://www.sublimelinter.com">SublimeLinter</a> 
+    with <a href="https://github.com/SublimeLinter/SublimeLinter-jsxhint">SublimeLinter-jsxhint</a>
+  </li>
+  <li><a href="https://github.com/6to5/6to5-sublime">6to5-sublime</a></li>
 </ul>
 <h4 id="mit-license">MIT License</h4>
 


### PR DESCRIPTION
Added links to the homepages for Sublime Text packages.

Changed syntax suggestion to the one supplied by 6to5 (which also includes ES6 React snippets). 

Changed eslint to JSXhint (compatible with 6to5 syntax) as a SublimeLinter plugin.