### PR TITLE
Update index.html to remove erroneous apostrophe.

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -253,7 +253,7 @@ export default React.createClass({
       </p>
 
       <p>
-        List's can automatically wrap an array of items
+        Lists can automatically wrap an array of items
         with ListItem components.
       </p>
 


### PR DESCRIPTION
The apostrophe is not needed here since "lists" is not possessive or a contraction of anything.